### PR TITLE
Add test optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,5 +10,8 @@ dependencies = [
     "mcp[cli]>=1.9.3",
 ]
 
+[project.optional-dependencies]
+test = ["pytest"]
+
 [tool.pytest.ini_options]
 pythonpath = "src"


### PR DESCRIPTION
## Summary
- add a `test` extra to simplify installing `pytest`

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'mcp')*


------
https://chatgpt.com/codex/tasks/task_e_689cd841c834832e9305a5f51949b43b