### PR TITLE
feat: add pydantic dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "python-dotenv>=0.23.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.9.3",
+    "pydantic>=2",
+    "pydantic-core>=2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add `pydantic` and `pydantic-core` to project dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'mcp'; ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_689cd94c4e68832e9dc7b9572ef4e0d0